### PR TITLE
feedback updates

### DIFF
--- a/bolt.css
+++ b/bolt.css
@@ -1,6 +1,6 @@
 /**
  * Bolt.css
- * Version 0.2.0
+ * Version 0.4.0
  * https://github.com/tbolt/boltcss
  *
  * Sections
@@ -15,15 +15,16 @@
  */
 
 :root {
-  --links: #4589ee;
   --highlight-border-radius: 7px;
   --border-radius: 11px;
 
+  --links: #0f6dff;
   --background-body: #fff;
   --background-main: #f1f1f1;
+  --background-inputs: #fcfcfc;
   --text: #1c1d1e;
   --border: #dddddd;
-  --hover-highlight: #b8b8b8;
+  --focus-highlight: #b8b8b8;
   --shadow-color: #545454;
   --table-highlight: #f1f1f1;
   --select-icon-url: url("data:image/svg+xml,%3Csvg width='292' height='292' viewBox='0 0 292 292' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cpath id='Path' fill='%23222222' stroke='none' d='M 287 69 C 283.606537 65.469971 278.895844 63.513214 274 63.600006 L 18.4 63.600006 C 13.4 63.600006 9.1 65.400009 5.5 69 C 1.984143 72.328568 -0.005267 76.958466 -0 81.800003 C -0 86.800003 1.8 91.100006 5.4 94.699997 L 133.399994 222.600006 C 137 226.200012 141.199997 228 146.199997 228 C 151.199997 228 155.399994 226.200012 159 222.600006 L 287 94.600006 C 290.5 91.100006 292.399994 86.800003 292.399994 81.800003 C 292.399994 76.800003 290.5 72.600006 286.899994 69 Z'/%3E%3C/svg%3E");
@@ -31,11 +32,13 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
+    --links: #4589ee;
     --background-body: #0f0f0f;
     --background-main: #222;
+    --background-inputs: #222;
     --text: #efefef;
     --border: #444;
-    --hover-highlight: #888;
+    --focus-highlight: #888;
     --shadow-color: #bebebe;
     --table-highlight: #222;
     --select-icon-url: url("data:image/svg+xml,%3Csvg width='292' height='292' viewBox='0 0 292 292' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cpath id='Path' fill='%23ffffff' stroke='none' d='M 287 69 C 283.606537 65.469971 278.895844 63.513214 274 63.600006 L 18.4 63.600006 C 13.4 63.600006 9.1 65.400009 5.5 69 C 1.984143 72.328568 -0.005267 76.958466 -0 81.800003 C -0 86.800003 1.8 91.100006 5.4 94.699997 L 133.399994 222.600006 C 137 226.200012 141.199997 228 146.199997 228 C 151.199997 228 155.399994 226.200012 159 222.600006 L 287 94.600006 C 290.5 91.100006 292.399994 86.800003 292.399994 81.800003 C 292.399994 76.800003 290.5 72.600006 286.899994 69 Z'/%3E%3C/svg%3E");
@@ -52,8 +55,8 @@ html,
 body {
   margin: 0;
   font-size: 12pt;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",
+    sans-serif;
   color: var(--text);
   background: var(--background-body);
 }
@@ -209,6 +212,8 @@ kbd,
 code,
 time {
   border-radius: var(--highlight-border-radius, 4px);
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 
 mark {
@@ -231,7 +236,8 @@ time {
   color: var(--text);
 }
 
-code {
+code,
+pre {
   font-size: 1em;
   padding: 2px 4px;
   background-color: whitesmoke;
@@ -249,6 +255,7 @@ pre > code {
 
 pre {
   margin: 0;
+  border-radius: var(--border-radius);
 }
 
 sup,
@@ -369,7 +376,7 @@ label {
 
 input {
   font-size: 1em;
-  background-color: var(--background-main);
+  background-color: var(--background-inputs);
   border: 1px solid var(--border);
   color: var(--text);
   margin: 6px 0px;
@@ -413,19 +420,19 @@ input[type="radio"]:checked {
 
 input[type="range"] {
   vertical-align: middle;
-  appearance: auto;
+  padding: 0;
 }
 
 textarea {
   font-family: inherit;
   font-size: 1em;
-  background-color: var(--background-main);
+  background-color: var(--background-inputs);
   border: 1px solid var(--border);
   padding: 11px;
   color: var(--text);
   border-radius: var(--border-radius);
   outline: none;
-  resize: none;
+  /* resize: none;  Todo: research if there is a non-js way to style/move grippie */
   max-width: 100%;
 }
 
@@ -442,7 +449,7 @@ select {
   box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
   border-radius: 0.5em;
   appearance: none;
-  background-color: var(--background-main);
+  background-color: var(--background-inputs);
   background-image: var(--select-icon-url);
   background-repeat: no-repeat, repeat;
   background-position: right 0.7em top 50%, 0 0;
@@ -455,11 +462,18 @@ select:is([multiple]) {
   height: fit-content;
 }
 
+fieldset:focus-within,
+input:focus-within,
+textarea:focus-within,
+select:focus-within {
+  border-color: var(--focus-highlight);
+}
+
 fieldset:hover,
 input:hover,
 textarea:hover,
 select:hover {
-  border-color: var(--hover-highlight);
+  border-color: var(--focus-highlight);
 }
 
 meter {

--- a/index.html
+++ b/index.html
@@ -218,14 +218,14 @@
     <!-- pre -->
     <h3 class="demo-header">pre</h3>
     <pre role="img" aria-label="ASCII COW">
-  ___________________________
- | I'm an expert in my field.|
-  ---------------------------
-      \   ^__^
-       \  (oo)\_______
-          (__)\       )\/\
-              ||----w |
-              ||     ||
+ ___________________________
+| I'm an expert in my field.|
+ ---------------------------
+    \   ^__^
+     \  (oo)\_______
+        (__)\       )\/\
+            ||----w |
+            ||     ||
     </pre>
 
     <!-- img -->
@@ -406,8 +406,8 @@
       <div>
         <h3 class="demo-header" id="rangedemo-label">range/output</h3>
         <form oninput="result.value=parseInt(rangedemo.value)">
-          <input type="range" id="rangedemo" name="rangedemo" value="50" aria-labelledby="rangedemo-label" />
-          <output name="result" for="b">60</output>
+          <input type="range" id="rangedemo" name="rangedemo" value="0" aria-labelledby="rangedemo-label" />
+          <output name="result" for="b">0</output>
         </form>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boltcss",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "Boltcss classless CSS stylesheet",
   "main": "bolt.css",
   "scripts": {},


### PR DESCRIPTION
updates links in light mode to meet wcag color contrast
updates form field backgrounds in light mode to not look disabled
adds box-decoration-break to better handle `<code>` and `<mark>` when wrapping
gives `<pre>` similar styling to `<code>`
adds `:focus-within` to maintain focus highlighting when using keyboard navigation
updates `[input type="range"]` to use default browser styles for now
bump version in package.json and bolt.css to 0.4.0