### PR TITLE
Remove space from link

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     <h2>How and why I made this</h2>
     <p>
       I used the fantastic
-      <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element"> HTML Elements Reference </a>
+      <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element">HTML Elements Reference</a>
       on MDN and modified it as needed.
     </p>
     <p>I created Bolt.css because I wanted to</p>


### PR DESCRIPTION
The space in the link in the README makes it not look quite as good as it's capable of looking, by having the underline go past the right end of the text.

<img width="467" alt="Captura de Pantalla 2023-03-15 a la(s) 14 50 45" src="https://user-images.githubusercontent.com/4126/225451877-8fe87a7d-94d7-42bb-b7cc-9e5dccce6de0.png">
